### PR TITLE
Cloud compose image

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,20 @@ Mongodb backups are implemented as ELB snapshots of the data volume. ELB snapsho
 * MONGODB_DAILY_SNAPSHOTS=7 - days to keep daily snapshots. Defaults to 7 days.
 * MONGODB_SNAPSHOT_FREQUENCY=10 - minutes between snapshots. Default is 10 minutes. Valid values are 5, 10, 15, or 20 minutes.
 
-## How do I do a subtree merge for sharing config files?
+## How do I do sharing config files?
+Since most of the config files are common between MongoDB clusters, it is desirable to directly share the configuration between projects. The recommend directory structure is to have docker-mongodb sub-directory and then a sub-directory for each cluster. For example if I had a test and prod mongodb cluster my directory structure would be:
+
+```
+mongodb/
+  docker-mongodb/cloud-compose/templates/
+  test/cloud-compose.yml
+  prod/cloud-compose.yml
+  templates/
+```
+
+The docker-mongodb directory would be a subtree merge of this Git project, the templates directory would be any common templates that only apply to your mongodb clusters, the the test and prod directories have the cloud-compose.yml files for your two mongodb clusters. Regardless of the directory structure, make sure the search_paths in your cloud-compose.yml reflect all the config directories and the order that you want to load the config files.
+
+## How do I create a subtree merge of this project?
 A subtree merge is an alternative to a Git submodules for copying the contents of one Github repo into another. It is easier to use once it is setup and does not require any special commands (unlike submodules) for others using your repo.
 
 ### Initial subtree merge

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Mongodb backups are implemented as ELB snapshots of the data volume. ELB snapsho
 * MONGODB_DAILY_SNAPSHOTS=7 - days to keep daily snapshots. Defaults to 7 days.
 * MONGODB_SNAPSHOT_FREQUENCY=10 - minutes between snapshots. Default is 10 minutes. Valid values are 5, 10, 15, or 20 minutes.
 
-## How do I do sharing config files?
+## How do I share config files?
 Since most of the config files are common between MongoDB clusters, it is desirable to directly share the configuration between projects. The recommend directory structure is to have docker-mongodb sub-directory and then a sub-directory for each cluster. For example if I had a test and prod mongodb cluster my directory structure would be:
 
 ```

--- a/cloud-compose/cloud-compose.yml.example
+++ b/cloud-compose/cloud-compose.yml.example
@@ -1,8 +1,8 @@
 cluster:
   name: ${CLUSTER_NAME}
   search_path:
-    - docker-mongodb
-    - docker-mongodb/cloud-compose/templates
+    - ../docker-mongodb
+    - ../docker-mongodb/cloud-compose/templates
   logging:
     driver: awslogs 
     meta:

--- a/cloud-compose/cloud-compose.yml.example
+++ b/cloud-compose/cloud-compose.yml.example
@@ -12,7 +12,6 @@ cluster:
     username: ${IMAGE_USERNAME}
     terminate_protection: false
     security_groups: ${SECURITY_GROUP_ID}
-    vpc: ${VPC_ID}
     ebs_optimized: false
     instance_type: t2.medium
     keypair: drydock

--- a/cloud-compose/cloud-compose.yml.example
+++ b/cloud-compose/cloud-compose.yml.example
@@ -8,7 +8,7 @@ cluster:
     meta:
       group: /cloud-compose/${CLUSTER_NAME}
   aws:
-    ami: ${IMAGE_ID}
+    ami: ${IMAGE_ID} or ${IMAGE_NAME_TAG}
     username: ${IMAGE_USERNAME}
     terminate_protection: false
     security_groups: ${SECURITY_GROUP_ID}

--- a/cloud-compose/templates/cluster.sh
+++ b/cloud-compose/templates/cluster.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
+{% include "system.resolv_conf.sh" %}
+{% include "system.limits_conf.sh" %}
 {% include "cloud.environment.sh" %}
 {% include "mongodb.hugepage.sh" %}
 {% include "mongodb.alias.sh" %}
 {% include "system.mounts.sh" %}
 {% include "docker.config.sh" %}
 {% include "docker_compose.run.sh" %}
+{% include "system.network_conf.sh" %}
 {# Optional template for datadog metrics
 {% include "datadog.mongodb.sh" %}
 #}

--- a/cloud-compose/templates/docker.config.sh
+++ b/cloud-compose/templates/docker.config.sh
@@ -1,7 +1,4 @@
 # docker.config.sh
-cat <<- 'EOF' > /home/{{ aws.username }}/.dockercfg
-{"quay.io":{"auth":"{{ QUAY_IO_AUTH }}","email":""{{'}}'}}
-EOF
 chown {{ aws.username }}:{{ aws.username }} /home/{{ aws.username }}/.dockercfg
 chmod 0644 /home/{{ aws.username }}/.dockercfg
 groupadd docker

--- a/cloud-compose/templates/docker.config.sh
+++ b/cloud-compose/templates/docker.config.sh
@@ -1,4 +1,11 @@
 # docker.config.sh
+cat <<- 'EOF' > /home/{{ aws.username }}/.dockercfg
+{"quay.io":{"auth":"{{ QUAY_IO_AUTH }}","email":""{{'}}'}}
+EOF
+chown {{ aws.username }}:{{ aws.username }} /home/{{ aws.username }}/.dockercfg
+chmod 0644 /home/{{ aws.username }}/.dockercfg
+groupadd docker
+usermod -aG docker {{ aws.username }}
 cat << EOF > /usr/lib/systemd/system/docker.service
 [Unit]
 Description=Docker Application Container Engine

--- a/cloud-compose/templates/docker.config.sh
+++ b/cloud-compose/templates/docker.config.sh
@@ -1,6 +1,4 @@
 # docker.config.sh
-chown {{ aws.username }}:{{ aws.username }} /home/{{ aws.username }}/.dockercfg
-chmod 0644 /home/{{ aws.username }}/.dockercfg
 groupadd docker
 usermod -aG docker {{ aws.username }}
 cat << EOF > /usr/lib/systemd/system/docker.service

--- a/cloud-compose/templates/docker_compose.run.sh
+++ b/cloud-compose/templates/docker_compose.run.sh
@@ -1,7 +1,4 @@
 # docker_compose.run.sh 
-curl -L https://github.com/docker/compose/releases/download/1.7.0/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
-chmod +x /usr/local/bin/docker-compose
-
 cat << EOF > /tmp/docker-compose.yml
 {{ docker_compose.yaml }}
 EOF
@@ -10,5 +7,5 @@ cat << EOF > /tmp/docker-compose.override.yml
 {{ docker_compose.override_yaml }}
 EOF
 
-runuser -l {{ aws.username }} -c "/usr/local/bin/docker-compose -f /tmp/docker-compose.yml -f /tmp/docker-compose.override.yml up -d"
+runuser -l {{ aws.username }} -c "docker-compose -f /tmp/docker-compose.yml -f /tmp/docker-compose.override.yml up -d"
 

--- a/cloud-compose/templates/mongodb.alias.sh
+++ b/cloud-compose/templates/mongodb.alias.sh
@@ -6,6 +6,7 @@ baseurl=https://repo.mongodb.org/yum/amazon/2013.03/mongodb-org/3.2/x86_64/
 gpgcheck=0
 enabled=1
 EOF
+
 yum -y install mongodb-org-shell
 {%- if MONGODB_ADMIN_PASSWORD is defined %}
 cat <<- 'EOF' > /etc/profile.d/mongo.sh

--- a/cloud-compose/templates/mongodb.alias.sh
+++ b/cloud-compose/templates/mongodb.alias.sh
@@ -1,3 +1,12 @@
+# mongodb.alias.sh 
+cat <<- 'EOF' > /etc/yum.repos.d/mongodb.repo
+[mongodb-org-3.2]
+name=MongoDB Repository
+baseurl=https://repo.mongodb.org/yum/amazon/2013.03/mongodb-org/3.2/x86_64/
+gpgcheck=0
+enabled=1
+EOF
+yum -y install mongodb-org-shell
 {%- if MONGODB_ADMIN_PASSWORD is defined %}
 cat <<- 'EOF' > /etc/profile.d/mongo.sh
 alias mongo='mongo -u admin -p {{ MONGODB_ADMIN_PASSWORD }} --authenticationDatabase admin'

--- a/cloud-compose/templates/mongodb.alias.sh
+++ b/cloud-compose/templates/mongodb.alias.sh
@@ -6,7 +6,6 @@ baseurl=https://repo.mongodb.org/yum/amazon/2013.03/mongodb-org/3.2/x86_64/
 gpgcheck=0
 enabled=1
 EOF
-
 yum -y install mongodb-org-shell
 {%- if MONGODB_ADMIN_PASSWORD is defined %}
 cat <<- 'EOF' > /etc/profile.d/mongo.sh

--- a/cloud-compose/templates/system.limits_conf.sh
+++ b/cloud-compose/templates/system.limits_conf.sh
@@ -1,0 +1,5 @@
+ulimit -n 1048576
+cat <<- 'EOF' >> /etc/security/limits.conf
+*                soft    nofile         1048576
+*                hard    nofile         1048576
+EOF

--- a/cloud-compose/templates/system.network_conf.sh
+++ b/cloud-compose/templates/system.network_conf.sh
@@ -1,0 +1,12 @@
+# system.network_conf.sh
+cat << EOF > /etc/sysctl.d/network.conf
+net.ipv4.tcp_fin_timeout = 30
+net.ipv4.tcp_tw_reuse = 1
+net.nf_conntrack_max = 512000
+net.ipv4.tcp_keepalive_intvl = 60 
+net.ipv4.tcp_keepalive_probes = 10 
+net.ipv4.tcp_keepalive_time = 600
+net.netfilter.nf_conntrack_tcp_timeout_established = 1800
+EOF
+echo 128000 > /sys/module/nf_conntrack/parameters/hashsize
+sysctl --system

--- a/cloud-compose/templates/system.resolv_conf.sh
+++ b/cloud-compose/templates/system.resolv_conf.sh
@@ -1,0 +1,9 @@
+{% if aws.dns is defined and aws.dns.nameserver is defined %}
+cat <<- EOF > /etc/resolv.conf
+domain ec2.internal
+search ec2.internal
+nameserver {{ aws.dns.nameserver }}
+EOF
+chattr +i /etc/resolv.conf
+{% endif %}
+


### PR DESCRIPTION
Added support for cloud-compose-image plugin by refactoring the templates that are in the base image vs the cluster up cloud_init.

**How was this tested?**
Create images for sandbox, wpit, and arc. Create mongodb clusters for each and checked replicaset health after launching.
