### PR TITLE
No journal option

### DIFF
--- a/cloud-compose/templates/docker-compose.override.yml
+++ b/cloud-compose/templates/docker-compose.override.yml
@@ -24,7 +24,9 @@ services:
       MONGODB_ADMIN_PASSWORD: {{ MONGODB_ADMIN_PASSWORD }}
     {%- endif %}
   mongodb:
-    {% if mongo and mongo.journal == False %}command: --shardsvr --dbpath /data/db --nojournal{% endif %}
+    {%- if mongo is defined and mongo.journal == False %}
+    command: --shardsvr --dbpath /data/db --nojournal
+    {%- endif %}
     image: washpost/mongodb:3.2
     extra_hosts:
     {%- for node in aws.nodes %}

--- a/cloud-compose/templates/docker-compose.override.yml
+++ b/cloud-compose/templates/docker-compose.override.yml
@@ -24,7 +24,7 @@ services:
       MONGODB_ADMIN_PASSWORD: {{ MONGODB_ADMIN_PASSWORD }}
     {%- endif %}
   mongodb:
-    {%- if mongo is defined and mongo.journal == False %}
+    {%- if mongo is defined and mongo.journal is defined and mongo.journal == False %}
     command: --shardsvr --dbpath /data/db --nojournal
     {%- endif %}
     image: washpost/mongodb:3.2

--- a/cloud-compose/templates/docker-compose.override.yml
+++ b/cloud-compose/templates/docker-compose.override.yml
@@ -24,6 +24,7 @@ services:
       MONGODB_ADMIN_PASSWORD: {{ MONGODB_ADMIN_PASSWORD }}
     {%- endif %}
   mongodb:
+    {% if mongo and mongo.journal == False %}command: --shardsvr --dbpath /data/db --nojournal{% endif %}
     image: washpost/mongodb:3.2
     extra_hosts:
     {%- for node in aws.nodes %}


### PR DESCRIPTION
## Changes

Added the ability to turn off the journal.  This takes a slight deviation in the style of the configuration.  You have to add a `mongo` field in the `cluster` clause of the cloud-compose.yml config file.

Example:

```
cluster:
  name: cool-cluster
  mongo:
    journal: false
...
```
