### PR TITLE
added oplog size and nojournal option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@ cloud-compose cluster up
 ```
 
 # FAQ
+## How do I tune the cluster?
+Most of the MongoDB settings default to sensible values, but if you have a write heavy cluster you may want to change the following options by adding environment variables to your cloud-compose.yml:
+
+* MONGODB_OPLOG_SIZE: 10000
+
+MONGODB_OPLOG_SIZE translates the the command line parameter `--oplogSize`. The value is the number of megabytes for the oplog. You can check if your oplog is big enough by running 1mongo --port 27018 --eval 'rs.printReplicationInfo()'`. If the output shows you have less than 24 hours between the first and last event, you may want to increase the size to be bigger.
+
+* MONGODB_JOURNAL: "false"
+
+MONGODB_JOURNAL translates to the command line parameter of `--nojournal`. If you are running a replicate set you can safely disable this by setting the value to `false` since you will be able to catch up an missed data from another replicat member. Disabling the journal has been show to reduce the start time by nearly 20 minutes for a write heavy cluster.
+
 ## How do I manage secrets?
 Secrets can be configured using environment variables. [Envdir](https://pypi.python.org/pypi/envdir) is highly recommended as a tool for switching between sets of environment variables in case you need to manage multiple clusters.
 At a minimum you will need AWS_ACCESS_KEY_ID, AWS_REGION, and AWS_SECRET_ACCESS_KEY. It is highly recommend that you also set MONGODB_ADMIN_PASSWORD to enable authentication.

--- a/cloud-compose/templates/docker-compose.override.yml
+++ b/cloud-compose/templates/docker-compose.override.yml
@@ -24,9 +24,6 @@ services:
       MONGODB_ADMIN_PASSWORD: {{ MONGODB_ADMIN_PASSWORD }}
     {%- endif %}
   mongodb:
-    {%- if mongo is defined and mongo.journal is defined and mongo.journal == False %}
-    command: --shardsvr --dbpath /data/db --nojournal
-    {%- endif %}
     image: washpost/mongodb:3.2
     extra_hosts:
     {%- for node in aws.nodes %}

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -21,6 +21,8 @@ services:
       CLUSTER_SIZE: 1
       NODE_LIST: mongodb
       MONGODB_ADMIN_PASSWORD: 123456789
+      MONGODB_OPLOG_SIZE: 500
+      MONGODB_JOURNAL: "false"
     links:
       - configdb
   configdb:

--- a/mongodb/entrypoint.sh
+++ b/mongodb/entrypoint.sh
@@ -125,6 +125,14 @@ if [ "$1" = 'mongod' ]; then
     params="$params --replSet ${MONGODB_REPL_SET}"
   fi
 
+  if [[ "$MONGODB_OPLOG_SIZE" ]]; then
+    params="$params --oplogSize ${MONGODB_OPLOG_SIZE}"
+  fi
+
+  if [[ "$MONGODB_JOURNAL" == "false" ]]; then
+    params="$params --nojournal"
+  fi
+
   if [[ "$NODE_ID" == "0" ]]; then
     rs_initiate &
   fi


### PR DESCRIPTION
This change adds environment variables for oplogSize and nojournal options. The nojournal option was available before, but it was only testable on EC2 instances. It also overrode the entire command line instead of just adding an additional parameter.
