### PR TITLE
added pcp and docker 1.12

### DIFF
--- a/cloud-compose/templates/cluster.sh
+++ b/cloud-compose/templates/cluster.sh
@@ -10,3 +10,4 @@
 {% include "docker_compose.run.sh" %}
 {% include "system.network_conf.sh" %}
 {% include "datadog.mongodb.sh" %}
+{% include "pcp.config.sh" %}

--- a/cloud-compose/templates/docker.config.sh
+++ b/cloud-compose/templates/docker.config.sh
@@ -1,6 +1,7 @@
 # docker.config.sh
 groupadd docker
 usermod -aG docker {{ aws.username }}
+{%- if ami is defined and ami == "docker:1.10" %}
 cat << EOF > /usr/lib/systemd/system/docker.service
 [Unit]
 Description=Docker Application Container Engine
@@ -22,10 +23,32 @@ MountFlags=slave
 [Install]
 WantedBy=multi-user.target
 EOF
+{%- else %}
+cat << EOF > /usr/lib/systemd/system/docker.service
+[Unit]
+Description=Docker Application Container Engine
+Documentation=https://docs.docker.com
+After=network.target
+
+[Service]
+Type=notify
+EnvironmentFile=-/etc/sysconfig/docker-storage
+ExecStart=/usr/bin/dockerd \$DOCKER_STORAGE_OPTIONS
+ExecReload=/bin/kill -s HUP \$MAINPID
+LimitNOFILE=infinity
+LimitNPROC=infinity
+LimitCORE=infinity
+TimeoutStartSec=0
+Delegate=yes
+KillMode=process
+
+[Install]
+WantedBy=multi-user.target
+EOF
+{%- endif %}
 
 # docker.start
 systemctl daemon-reload
 chkconfig docker on
 systemctl enable docker
 service docker start
-

--- a/cloud-compose/templates/pcp.config.sh
+++ b/cloud-compose/templates/pcp.config.sh
@@ -1,0 +1,9 @@
+# pcp.config.sh
+{%- if PERFORMANCE_COPILOT is defined and PERFORMANCE_COPILOT == "enabled" %}
+chkconfig pmcd on
+service pmcd start
+chkconfig pmlogger on
+service pmlogger start
+chkconfig pmwebd on
+service pmwebd start
+{%- endif %}


### PR DESCRIPTION
This change adds support for docker 1.12 and pcp for performance monitoring. Tested in AWS sandbox account with docker 1.12 and 1.10 images.