### PR TITLE
use ami name

### DIFF
--- a/cloud-compose/templates/docker.config.sh
+++ b/cloud-compose/templates/docker.config.sh
@@ -1,7 +1,7 @@
 # docker.config.sh
 groupadd docker
 usermod -aG docker {{ aws.username }}
-{%- if aws is defined and aws.ami is defined and aws.ami == "docker:1.10" %}
+{%- if aws is defined and aws.ami_name is defined and aws.ami_name == "docker:1.10" %}
 cat << EOF > /usr/lib/systemd/system/docker.service
 [Unit]
 Description=Docker Application Container Engine


### PR DESCRIPTION
use aws.ami_name instead because aws.ami is overwritten with the actual ami value.  based on https://github.com/cloud-compose/cloud-compose-cluster/pull/28