### PR TITLE
Adding support for 3.6, to ease migrations into Atlas

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -38,3 +38,4 @@ function deploy() {
 
 deploy 3.2 3.2.12 false 
 deploy 3.4 3.4.2 true
+deploy 3.6 3.6.20 false

--- a/mongodb/3.6/Dockerfile
+++ b/mongodb/3.6/Dockerfile
@@ -1,0 +1,64 @@
+FROM debian:jessie
+
+# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
+RUN groupadd -r mongodb && useradd -r -g mongodb mongodb
+
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
+		curl netcat numactl \
+	&& rm -rf /var/lib/apt/lists/*
+
+# grab gosu for easy step-down from root
+ENV GOSU_VERSION 1.7
+RUN set -x \
+	&& apt-get update && apt-get install -y --no-install-recommends ca-certificates wget && rm -rf /var/lib/apt/lists/* \
+	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
+	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
+	&& export GNUPGHOME="$(mktemp -d)" \
+	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
+	&& rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+	&& chmod +x /usr/local/bin/gosu \
+	&& gosu nobody true \
+	&& apt-get purge -y --auto-remove ca-certificates wget
+
+ENV GPG_KEYS \
+	2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5
+
+RUN set -ex; \
+	export GNUPGHOME="$(mktemp -d)"; \
+	for key in $GPG_KEYS; do \
+		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	done; \
+	gpg --export $GPG_KEYS > /etc/apt/trusted.gpg.d/mongodb.gpg; \
+	rm -r "$GNUPGHOME"; \
+	apt-key list
+
+ENV MONGO_MAJOR 3.6
+ENV MONGO_VERSION 3.6.20
+ENV MONGO_PACKAGE mongodb-org
+
+RUN echo "deb http://repo.mongodb.org/apt/debian jessie/mongodb-org/$MONGO_MAJOR main" > /etc/apt/sources.list.d/mongodb-org.list
+
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install -y \
+		${MONGO_PACKAGE}=$MONGO_VERSION \
+		${MONGO_PACKAGE}-server=$MONGO_VERSION \
+		${MONGO_PACKAGE}-shell=$MONGO_VERSION \
+		${MONGO_PACKAGE}-mongos=$MONGO_VERSION \
+		${MONGO_PACKAGE}-tools=$MONGO_VERSION \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& rm -rf /var/lib/mongodb \
+	&& mv /etc/mongod.conf /etc/mongod.conf.orig
+
+RUN mkdir -p /data/db && chown -R mongodb:mongodb /data/db
+VOLUME /data/db
+
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+
+EXPOSE 27017
+EXPOSE 27018
+EXPOSE 27019
+CMD ["mongod"]

--- a/mongodb/3.6/entrypoint.sh
+++ b/mongodb/3.6/entrypoint.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+set -e
+set -x
+
+if [[ "$MONGODB_ADMIN_PASSWORD" ]]; then
+  mongo="mongo -u admin -p ${MONGODB_ADMIN_PASSWORD} --authenticationDatabase admin"
+else
+  mongo="mongo"
+fi
+
+function auth_initiate() {
+  params="$@"
+	gosu mongodb $params &
+  pid=$!
+
+  while ! nc -z localhost $MONGODB_PORT; do
+    echo "waiting for mongodb to start"
+    sleep 1
+  done
+
+  mongo localhost:$MONGODB_PORT/admin --eval "if(!db.getUser(\"admin\")) { printjson(db.createUser({user: \"admin\", pwd: \"${MONGODB_ADMIN_PASSWORD}\", roles: [{role: \"root\", db: \"admin\"}, {role: \"userAdminAnyDatabase\", db: \"admin\"}, {role: \"readAnyDatabase\", db: \"admin\"}]})) }"
+
+  echo 'killing mongodb after auth initiation'
+  kill -2 $pid
+
+  while nc -z localhost $MONGODB_PORT; do
+    echo "waiting for mongodb to stop"
+    sleep 1
+  done
+
+  while [ -s /data/db/mongod.lock ]; do
+    echo 'waiting for /data/db/mongod.lock to disappear'
+    sleep 1
+  done
+}
+
+function is_replica_set() {
+  IFS=',' read -r -a nodes <<< "$NODE_LIST"
+  for node in "${nodes[@]}"
+  do
+    echo "$mongo $node:$MONGODB_PORT/admin --quiet --eval \"rs.status().set\" | grep -q \"^${MONGODB_REPL_SET}\""
+    $mongo $node:$MONGODB_PORT/admin --quiet --eval "rs.status().set" | grep -q "^${MONGODB_REPL_SET}"
+    if [ "$?" == "0" ]; then
+      echo "$node already a replica set"
+      return 0
+    fi
+  done
+  return 1
+}
+
+function rs_initiate() {
+  if [ -z "$MONGODB_PORT" ]; then
+    echo "MONGODB_PORT environment variable must be set"
+    exit 1
+  fi
+
+  if [ -z "$NODE_LIST" ]; then
+    echo "NODE_LIST environment variable must be set"
+    exit 1
+  fi
+
+  while ! nc -z localhost $MONGODB_PORT; do
+    echo "waiting for mongodb to start"
+    sleep 1
+  done
+
+  if ! is_replica_set; then
+    echo "node$NODE_ID initiating replica set..."
+    local first_node=0
+    IFS=',' read -r -a nodes <<< "$NODE_LIST"
+    for node in "${nodes[@]}"
+    do
+      if [ "$first_node" == "0" ]; then
+        first_node=1
+        $mongo localhost:$MONGODB_PORT/admin --quiet --eval "printjson(rs.initiate({_id: \"$MONGODB_REPL_SET\", version: 1, members: [ { _id: 0, host : \"$node:$MONGODB_PORT\" } ] }))"
+
+        while ! $mongo localhost:$MONGODB_PORT/admin --quiet --eval "db.isMaster().ismaster" | grep true
+        do
+          echo "waiting for $node to become primary"
+          sleep 1
+        done
+
+      else
+        while $mongo localhost:$MONGODB_PORT/admin --quiet --eval "printjson(rs.add(\"$node:$MONGODB_PORT\"))" | grep -l '"ok"\s*:\s*0'
+        do
+          echo "failed to add $node to mongodb replica set"
+          sleep 1
+        done
+      fi
+    done
+  fi
+}
+
+if [ "${1:0:1}" = '-' ]; then
+	set -- mongod "$@"
+fi
+
+if [ "$1" = 'mongod' ]; then
+	chown -R mongodb /data/db
+
+	numa='numactl --interleave=all'
+	if $numa true &> /dev/null; then
+		set -- $numa "$@"
+	fi
+
+  params="$@"
+  # mongo 3.6 binds to localhost by default. it would be better
+  # to parse /etc/hosts, probably, but since these should just be
+  # used for migrations let's imitate the behavior of mongo 3.4 and lower
+  params="$params --bind_ip_all"
+
+  if [[ "$MONGODB_ADMIN_PASSWORD" ]]; then
+    if [[ "$NODE_ID" == "0" ]]; then
+      if [ ! -e /data/db/mongod.lock ]; then 
+        # only initiate auth if this is the first time running and there is no previous lock file
+        auth_initiate "$params"
+      fi
+    fi
+
+    if [[ "$MONGODB_KEYFILE" ]]; then
+      echo "$MONGODB_KEYFILE" > /tmp/mongodb-keyfile
+    else
+      echo "$MONGODB_ADMIN_PASSWORD" | base64 > /tmp/mongodb-keyfile
+    fi
+    chmod 600 /tmp/mongodb-keyfile
+    chown mongodb /tmp/mongodb-keyfile
+    params="$params --keyFile=/tmp/mongodb-keyfile"
+  fi
+
+  if [[ "$MONGODB_REPL_SET" ]]; then
+    params="$params --replSet ${MONGODB_REPL_SET}"
+  fi
+
+  if [[ "$MONGODB_OPLOG_SIZE" ]]; then
+    params="$params --oplogSize ${MONGODB_OPLOG_SIZE}"
+  fi
+
+  if [[ "$MONGODB_JOURNAL" == "false" ]]; then
+    params="$params --nojournal"
+  fi
+
+  if [[ "$NODE_ID" == "0" ]]; then
+    rs_initiate &
+  fi
+
+	exec gosu mongodb $params
+
+else
+  exec "$@"
+fi

--- a/mongos/3.6/Dockerfile
+++ b/mongos/3.6/Dockerfile
@@ -1,0 +1,63 @@
+FROM debian:jessie
+
+# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
+RUN groupadd -r mongodb && useradd -r -g mongodb mongodb
+
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
+		curl netcat numactl \
+	&& rm -rf /var/lib/apt/lists/*
+
+# grab gosu for easy step-down from root
+ENV GOSU_VERSION 1.7
+RUN set -x \
+	&& apt-get update && apt-get install -y --no-install-recommends ca-certificates wget && rm -rf /var/lib/apt/lists/* \
+	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
+	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
+	&& export GNUPGHOME="$(mktemp -d)" \
+	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
+	&& rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+	&& chmod +x /usr/local/bin/gosu \
+	&& gosu nobody true \
+	&& apt-get purge -y --auto-remove ca-certificates wget
+
+ENV GPG_KEYS \
+	2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5
+RUN set -ex; \
+	export GNUPGHOME="$(mktemp -d)"; \
+	for key in $GPG_KEYS; do \
+		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	done; \
+	gpg --export $GPG_KEYS > /etc/apt/trusted.gpg.d/mongodb.gpg; \
+	rm -r "$GNUPGHOME"; \
+	apt-key list
+
+ENV MONGO_MAJOR 3.6
+ENV MONGO_VERSION 3.6.20
+ENV MONGO_PACKAGE mongodb-org
+
+RUN echo "deb http://repo.mongodb.org/apt/debian jessie/mongodb-org/$MONGO_MAJOR main" > /etc/apt/sources.list.d/mongodb-org.list
+
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install -y \
+		${MONGO_PACKAGE}=$MONGO_VERSION \
+		${MONGO_PACKAGE}-server=$MONGO_VERSION \
+		${MONGO_PACKAGE}-shell=$MONGO_VERSION \
+		${MONGO_PACKAGE}-mongos=$MONGO_VERSION \
+		${MONGO_PACKAGE}-tools=$MONGO_VERSION \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& rm -rf /var/lib/mongodb \
+	&& mv /etc/mongod.conf /etc/mongod.conf.orig
+
+RUN mkdir -p /data/db && chown -R mongodb:mongodb /data/db
+VOLUME /data/db
+
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+
+EXPOSE 27017
+EXPOSE 27018
+EXPOSE 27019
+CMD ["mongos"]

--- a/mongos/3.6/entrypoint.sh
+++ b/mongos/3.6/entrypoint.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+set -e
+
+if [[ "$MONGODB_ADMIN_PASSWORD" ]]; then
+  mongo="mongo -u admin -p ${MONGODB_ADMIN_PASSWORD} --authenticationDatabase admin"
+else
+  mongo="mongo"
+fi
+
+function wait_for_startup() {
+  local host="$1"
+  local port="$2"
+  local primary="${3:-1}"
+  while ! nc -z $host $port; do
+    echo "waiting for $host:$port to start"
+    sleep 1
+  done
+
+  if [ "$primary" == "1" ]; then
+    echo "checking for primary status for $host:$port"
+
+    while ! $mongo $host:$port/admin --quiet --eval "rs.status()" | grep PRIMARY
+    do
+      echo "waiting for $host:$port to be elected primary"
+      sleep 1
+    done
+  fi
+}
+
+function add_shard() {
+  if [ -z "$MONGODB_REPL_SET" ]; then
+    echo "MONGODB_REPL_SET environment variable must be set"
+    exit 1
+  fi
+  wait_for_startup localhost 27017 0
+
+  echo $mongo
+  $mongo localhost:27017 --quiet --eval "db = db.getSiblingDB('config'); if (!db.shards.count()) { printjson(sh.addShard(\"$MONGODB_REPL_SET/$MONGODB_SHARD:27018\"))}"
+}
+
+if [ "${1:0:1}" = '-' ]; then
+	set -- mongos "$@"
+fi
+
+if [ "$1" = 'mongos' ]; then
+	chown -R mongodb /data/db
+
+	numa='numactl --interleave=all'
+	if $numa true &> /dev/null; then
+		set -- $numa "$@"
+	fi
+
+  wait_for_startup $MONGODB_HOST 27018
+  wait_for_startup $CONFIGDB_HOST 27019
+
+  params="$@"
+
+  if [[ "$MONGODB_ADMIN_PASSWORD" ]]; then
+    echo "$MONGODB_ADMIN_PASSWORD" | base64 > /tmp/mongodb-keyfile
+    chmod 600 /tmp/mongodb-keyfile
+    chown mongodb /tmp/mongodb-keyfile
+    params="$params --keyFile=/tmp/mongodb-keyfile"
+  fi
+
+  if [[ $MONGODB_SHARD ]]; then
+    if [[ "$NODE_ID" == "0" ]]; then
+      add_shard &
+    fi
+  fi
+
+	exec gosu mongodb $params
+fi
+
+exec "$@"


### PR DESCRIPTION
The `snapshots` docker container no longer builds, I think because of python 2.7 EOL. I've tested out this 3.6 image on some of our legacy cloud-compose mongo clusters, and it seems to be working. 